### PR TITLE
Change context upon namespace creation

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -155,4 +155,9 @@ func createOrUpdate(projectDir, namespace string, dryRun, create bool, rawValues
 		return
 	}
 	logger.Infof("Creation is complete, enjoy using %s", namespace)
+
+	err = cluster.SetContextNamespace(cmd, namespace)
+	if err != nil {
+		logger.Warn("Unable to set namespace in context.")
+	}
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -154,12 +154,12 @@ func createOrUpdate(projectDir, namespace string, dryRun, create bool, rawValues
 		logger.Error(err)
 		return
 	}
-	logger.Infof("Creation is complete, enjoy using %s", namespace)
 
 	err = cluster.SetContextNamespace(cmd, namespace)
 	if err != nil {
 		logger.Warn("Unable to set namespace in context.")
 	}
+
 	if dryRun {
 		logger.Infof("Dry-run is complete, this is what will be deployed.")
 	} else {

--- a/internal/cluster/kubectl.go
+++ b/internal/cluster/kubectl.go
@@ -51,3 +51,9 @@ func ListEnvironments(cmd commands.Command) []string {
 	}
 	return namespaces
 }
+
+// SetContextNamespace triggers a command to set kubectl context to the new namespace
+func SetContextNamespace(cmd commands.Command, namespace string) error {
+	_, err := cmd.Exec("update-context", "kubectl", "config", "set-context", "--current", "--namespace", namespace)
+	return err
+}

--- a/internal/cluster/kubectl_test.go
+++ b/internal/cluster/kubectl_test.go
@@ -143,3 +143,36 @@ test              Active    10d
 		})
 	}
 }
+
+func TestSetContextNamespace(t *testing.T) {
+	cases := []struct {
+		name      string
+		cmd       commands.Command
+		namespace string
+		wantErr   bool
+	}{
+		{
+			name:      "any-name",
+			cmd:       commands.CmdMock{CmdExecuted: "kubectl config set-context --current --namespace any-name", ReturnError: false},
+			namespace: "any-name",
+			wantErr:   false,
+		},
+		{
+			name:      "no-name",
+			cmd:       commands.CmdMock{CmdExecuted: "kubectl config set-context --current --namespace", ReturnError: true},
+			namespace: "",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SetContextNamespace(tt.cmd, tt.namespace)
+			if err != nil && !tt.wantErr {
+				t.Errorf("%s test failed. \nGot: %v \nExpected: %v", tt.name, err, tt.wantErr)
+			}
+			if err == nil && tt.wantErr {
+				t.Errorf("%s test failed.\nExpected: %v but got no error", tt.name, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
- Fix: Armador will try to set the context to the new namespace after creation.
**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
